### PR TITLE
Relax administrate version requirement

### DIFF
--- a/administrate-field-shrine.gemspec
+++ b/administrate-field-shrine.gemspec
@@ -23,13 +23,13 @@ Gem::Specification.new do |spec|
   end
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{\A(test|spec|features)/}) || f.match(%r{.*\.gem\z})
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'administrate', '~> 0.5.0'
+  spec.add_dependency 'administrate', '> 0.5.0', '~> 0.9.0'
   spec.add_dependency 'rails', '>= 4.2', '< 5.2'
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
Current version of administrate is 0.9.0

Also fix start and end matchers on regex.