### PR TITLE
Add derivatives plugin compatibility

### DIFF
--- a/lib/administrate/field/shrine.rb
+++ b/lib/administrate/field/shrine.rb
@@ -13,7 +13,13 @@ module Administrate
       # however, once data[:version].url is available data.url won't work,
       # so we're covered in both cases
       def url
-        (regular_url || version_url).to_s
+        if derivative
+          derivative_url || regular_url
+        elsif version
+          version_url
+        else
+          regular_url
+        end
       end
 
       def regular_url
@@ -21,15 +27,23 @@ module Administrate
       end
 
       def version_url
-        data.try(:[], version).try(:url)
-      end
-
-      def url_only?
-        options.fetch(:url_only, false)
+        resource.try((attribute.to_s + '_url').to_sym, version)
       end
 
       def version
         options.fetch(:version, nil)
+      end
+
+      def derivative_url
+        resource.try((attribute.to_s + '_url').to_sym, derivative)
+      end
+
+      def derivative
+	      options.fetch(:derivative, nil)
+      end
+
+      def url_only?
+        options.fetch(:url_only, false)
       end
 
       def cached_value


### PR DESCRIPTION
Hi, hope everything is well down under. :smile:

This is a work in progress, compatibility with the new derivatives plugin (which replaces versions) works, instead of `version` in the options you have to specify `derivative`. But, I haven't tested back compatibility with the versions plugin much. Will try to set up a project with an older shrine version (2.x) and the versions plugin and test it out.

```ruby
image: Field::Shrine.with_options(
  derivative: :medium
)
```