### PR TITLE
add option to set the size of the image tag

### DIFF
--- a/app/views/fields/shrine/_index.html.erb
+++ b/app/views/fields/shrine/_index.html.erb
@@ -1,5 +1,5 @@
 <% if field.url_only? -%>
 <%= link_to field.url, field.url if field.url.present? %>
 <% else -%>
-<%= image_tag field.url %>
+<%= image_tag field.url, size: field.size %>
 <% end -%>

--- a/app/views/fields/shrine/_show.html.erb
+++ b/app/views/fields/shrine/_show.html.erb
@@ -1,5 +1,5 @@
 <% if field.url_only? -%>
 <%= link_to field.url, field.url if field.url.present? %>
 <% else -%>
-<%= image_tag field.url if field.url.present? %>
+<%= image_tag field.url, size: field.size if field.url.present? %>
 <% end -%>

--- a/lib/administrate/field/shrine.rb
+++ b/lib/administrate/field/shrine.rb
@@ -35,6 +35,10 @@ module Administrate
       def cached_value
         resource.send("cached_#{attribute}_data")
       end
+
+      def size
+        options.fetch(:size, nil)
+      end
     end
   end
 end


### PR DESCRIPTION
This provides a new option to be able to specify the size of the image tag in the show and index actions. The syntax is the same as in the [image_tag](https://apidock.com/rails/ActionView/Helpers/AssetTagHelper/image_tag)